### PR TITLE
Fixed the en-US locale handler

### DIFF
--- a/index.php
+++ b/index.php
@@ -56,11 +56,11 @@ function normalize_date($time_string, $swap){
   if($swap){
     $arr = explode('/', $time_string);
     // YYYY/MM/DD
-    if(count($arr[0]) == 4) {
+    if(strlen($arr[0]) == 4) {
       $tmp = $arr[2];
-      $arr[2] = $arr[1];
-      $arr[1] = $arr[0];
-      $arr[0] = $tmp;
+      $arr[2] = $arr[0];
+      $arr[0] = $arr[1];
+      $arr[1] = $tmp;
       return implode('/', $arr);
     } else {
       // MM/DD/YYYY


### PR DESCRIPTION
The US locale handler was assumed to work without modification but that's not the case. I have fixed the handler and it should work perfectly now. YYYY/MM/DD was normalized incorrectly to DD/YYYY/MM. PHP only accepts MM/DD/YYYY format by default, and I have changed it to this format. I have conducted tests and it should work now.
